### PR TITLE
Fix/patron2020 correct koin for coordinator

### DIFF
--- a/app/src/main/java/com/intive/patronage/smarthome/dashboard/DashboardModule.kt
+++ b/app/src/main/java/com/intive/patronage/smarthome/dashboard/DashboardModule.kt
@@ -1,12 +1,16 @@
 package com.intive.patronage.smarthome.dashboard
 
+import androidx.appcompat.app.AppCompatActivity
 import com.intive.patronage.smarthome.dashboard.model.DashboardSensor
 import com.intive.patronage.smarthome.dashboard.view.SensorsListAdapter
 import com.intive.patronage.smarthome.dashboard.viewmodel.DashboardViewModel
+import com.intive.patronage.smarthome.navigator.DashboardCoordinator
+import com.intive.patronage.smarthome.navigator.Navigator
 import org.koin.dsl.module
 import org.koin.android.viewmodel.dsl.viewModel
 
 val dashboardModule = module {
     factory { (onItemClickListener: (sensor: DashboardSensor)-> Unit) -> SensorsListAdapter(onItemClickListener) }
     viewModel { DashboardViewModel(get()) }
+    factory { (activity: AppCompatActivity) -> DashboardCoordinator(Navigator(activity)) }
 }

--- a/app/src/main/java/com/intive/patronage/smarthome/dashboard/view/SmartHomeActivity.kt
+++ b/app/src/main/java/com/intive/patronage/smarthome/dashboard/view/SmartHomeActivity.kt
@@ -17,10 +17,7 @@ import org.koin.core.parameter.parametersOf
 
 class SmartHomeActivity : AppCompatActivity() {
 
-
-    private val navigator = Navigator(this)
-    private val dashboardCoordinator = DashboardCoordinator(navigator)
-
+    private val dashboardCoordinator: DashboardCoordinator by inject { parametersOf(this) }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/app/src/main/java/com/intive/patronage/smarthome/splashscreen/SplashScreenModule.kt
+++ b/app/src/main/java/com/intive/patronage/smarthome/splashscreen/SplashScreenModule.kt
@@ -10,8 +10,8 @@ import org.koin.dsl.module
 val splashScreenModule: Module = module {
     single { SmartHomeAlertDialog() }
     viewModel { SplashScreenViewModel(get()) }
-    single { Navigator(get()) }
-    single { (activity: AppCompatActivity) -> SplashScreenCoordinator(Navigator(activity)) }
+    factory { Navigator(get()) }
+    factory { (activity: AppCompatActivity) -> SplashScreenCoordinator(Navigator(activity)) }
 }
 
 


### PR DESCRIPTION
Poprawiony został koin 

1. Wchodzimu do apki
2. Pojawia się splash screen
3. Przechodzimy do dashboard
4. Kilkamy back button i wychodzimy z apki
5 . Po wejściu do apki jeszcze raz od nowa pojawia się nam splash screen
6.  Przechodzimy do dashbordu klikamy back i to powodowalo pojawienie się splash screena

Teraz gdy klikniemy back zawsze przeniesie nas do home screena

Koordynator jest wstrzykiwany w SplashScreenieActivity i DashBoardzie - SmartHomeActivity